### PR TITLE
[bug fix] not to add new line after default import

### DIFF
--- a/lib/rules/utils.js
+++ b/lib/rules/utils.js
@@ -29,33 +29,25 @@ function lintModuleVariablesNewline(node, context, moduleType) {
 
   for (let i = 1; i < moduleVariables.length; i++) {
     const firstTokenOfCurrentProperty = sourceCode.getFirstToken(moduleVariables[i]);
-    if (moduleVariables[i].loc.start.line === moduleVariables[i - 1].loc.start.line) {
+    const namedImportAfterDefault = moduleType === IMPORT
+      && node.specifiers[i].type === 'ImportSpecifier'
+      && (
+        node.specifiers[i - 1]
+        && node.specifiers[i - 1].type === 'ImportDefaultSpecifier'
+      );
+    if (!namedImportAfterDefault && moduleVariables[i].loc.start.line === moduleVariables[i - 1].loc.start.line) {
       context.report({
         node,
         message: `Each ${moduleTypeNameForMessage} variable should starts with a new line`,
         fix(fixer) {
 
           const sourceCode = context.getSourceCode();
-          const namedImportAfterDefault = moduleType === IMPORT
-            && node.specifiers[i].type === 'ImportSpecifier'
-            && (
-              node.specifiers[i - 1]
-              && node.specifiers[i - 1].type === 'ImportDefaultSpecifier'
-            );
 
           let comma = null;
           let rangeAfterComma = null;
 
           if (namedImportAfterDefault) {
-            const commaRange = [node.specifiers[i - 1].range[1], node.specifiers[i].range[0]];
-            const comma = sourceCode.tokensAndComments.find(
-              (token) =>
-                token.type === "Punctuator" &&
-                token.range[0] >= commaRange[0] &&
-                token.range[1] <= commaRange[1]
-            );
-            rangeAfterComma = [comma.range[0], comma.range[1]];
-            return fixer.replaceTextRange(rangeAfterComma, ",\n");
+            return null;
           } else {
             comma = sourceCode.getTokenBefore(firstTokenOfCurrentProperty);
             rangeAfterComma = [comma.range[1], firstTokenOfCurrentProperty.range[0]];


### PR DESCRIPTION
## Abstract

In current version, there is a new line after default import as below, but I think this is not expected.

```
import React,
{
  useState,
  useEffect
} from 'react'
```

I think there should not exist a new line after default import, and should exist after blace of named exports as below.

```
import React, {
  useState,
  useEffect
} from 'react'
```