### PR TITLE
[feat / bugfix]: allow default import and one named import in same line to avoid conflict for with object-curly-newline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/rules/utils.js
+++ b/lib/rules/utils.js
@@ -30,42 +30,45 @@ function lintModuleVariablesNewline(node, context, moduleType) {
   for (let i = 1; i < moduleVariables.length; i++) {
     const firstTokenOfCurrentProperty = sourceCode.getFirstToken(moduleVariables[i]);
     if (moduleVariables[i].loc.start.line === moduleVariables[i - 1].loc.start.line) {
-      context.report({
+      const report = (fixer) => context.report({
         node,
         message: `Each ${moduleTypeNameForMessage} variable should starts with a new line`,
-        fix(fixer) {
-
-          const sourceCode = context.getSourceCode();
-          const namedImportAfterDefault = moduleType === IMPORT
-            && node.specifiers[i].type === 'ImportSpecifier'
-            && (
-              node.specifiers[i - 1]
-              && node.specifiers[i - 1].type === 'ImportDefaultSpecifier'
-            );
-
-          if (namedImportAfterDefault) {
-            const endOfDefaultImport = node.specifiers[i - 1].range[1];
-            const beginningOfNamedImport = node.specifiers[i].range[0];
-
-            const brace = sourceCode.tokensAndComments.find(
-              (token) => token.type === "Punctuator"
-                && token.value === "{"
-                && token.range[0] >= endOfDefaultImport
-                && token.range[1] <= beginningOfNamedImport
-            );
-            const rangeAfterBrace = [brace.range[0], brace.range[1]];
-            return fixer.replaceTextRange(rangeAfterBrace, "{\n");
-          } else {
-            const comma = sourceCode.getTokenBefore(firstTokenOfCurrentProperty);
-            const rangeAfterComma = [comma.range[1], firstTokenOfCurrentProperty.range[0]];
-            // don't fix if comments between the comma and the next property.
-            if (sourceCode.text.slice(rangeAfterComma[0], rangeAfterComma[1]).trim()) {
-              return null;
-            }
-            return fixer.replaceTextRange(rangeAfterComma, "\n");
-          }
-        },
+        fix: fixer,
       });
+
+      const sourceCode = context.getSourceCode();
+      const namedImportAfterDefault = moduleType === IMPORT
+        && node.specifiers[i].type === 'ImportSpecifier'
+        && (
+          node.specifiers[i - 1]
+          && node.specifiers[i - 1].type === 'ImportDefaultSpecifier'
+        );
+
+      if (namedImportAfterDefault) {
+        if (moduleVariables.length <= 2) {
+          return null;
+        }
+        const endOfDefaultImport = node.specifiers[i - 1].range[1];
+        const beginningOfNamedImport = node.specifiers[i].range[0];
+
+        const brace = sourceCode.tokensAndComments.find(
+          (token) => token.type === "Punctuator"
+            && token.value === "{"
+            && token.range[0] >= endOfDefaultImport
+            && token.range[1] <= beginningOfNamedImport
+        );
+        const rangeAfterBrace = [brace.range[0], brace.range[1]];
+
+        report((fixer) => fixer.replaceTextRange(rangeAfterBrace, "{\n"));
+      } else {
+        const comma = sourceCode.getTokenBefore(firstTokenOfCurrentProperty);
+        const rangeAfterComma = [comma.range[1], firstTokenOfCurrentProperty.range[0]];
+        // don't fix if comments between the comma and the next property.
+        if (sourceCode.text.slice(rangeAfterComma[0], rangeAfterComma[1]).trim()) {
+          return null;
+        }
+        report((fixer) => fixer.replaceTextRange(rangeAfterComma, "\n"));
+      }
     }
   }
 }

--- a/tests/import.test.js
+++ b/tests/import.test.js
@@ -20,8 +20,9 @@ ruleTester.run("import-declaration-newline", rule, {
     "import { k1 } from 'something';",
     "import {\nk1\n} from 'something';",
     "import {} from 'something';",
-    "import React, {\n useState } from 'react';",
+    "import React, { useState } from 'react';",
     "import React, {\nuseState } from 'react';",
+    "import React, {\nuseState, \nuseEffect } from 'react'",
   ],
   invalid: [
     {
@@ -38,6 +39,22 @@ ruleTester.run("import-declaration-newline", rule, {
     {
       code: "import { k1, k2, k3 } from 'something';",
       output: "import { k1,\nk2,\nk3 } from 'something';",
+      errors: [
+        {
+          type: "ImportDeclaration",
+          line: 1,
+          column: 1,
+        },
+        {
+          type: "ImportDeclaration",
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: "import React, { useState, useEffect } from 'react';",
+      output: "import React, {\n useState,\nuseEffect } from 'react';",
       errors: [
         {
           type: "ImportDeclaration",


### PR DESCRIPTION
At the first, I'm sorry about my patch #8 causes a bug. @gmsorrow 

Using this plugin and `object-curly-newline` in same config, these fixers are conflicted, and it would never resolved.
In case that default import and one named import in same line, I think adding newline is a responsibility of `object-curly-newline`, not this plugin. So, I modified to pass lint in this case. (See test cases)
This version works with `object-curly-newline` well.